### PR TITLE
Allow beam_size and alpha to be modified during decoding

### DIFF
--- a/run-t2t.sh
+++ b/run-t2t.sh
@@ -191,8 +191,7 @@ if [[ -f $DECODE_FILE ]]; then
           --model=$MODEL
           --hparams_set=$HPARAMS
           --output_dir=$OUTPUT_DIR
-          --decode_beam_size=$BEAM_SIZE
-          --decode_alpha=$ALPHA
+          --decode_params=beam_size=$BEAM_SIZE,alpha=$ALPHA
           --decode_from_file=$DECODE_FILE
           --decode_to_file=$DECODE_FILE_OUT_PATH $DECODER_FLAGS"
         logMessage "$cmd"


### PR DESCRIPTION
Code ignores the decode_beam_size and decode_alpha FLAGS, but uses decode_params as a comma delimited list to pass overrides to hparams.